### PR TITLE
fix: Renamed the export for education input validation

### DIFF
--- a/validation/education.js
+++ b/validation/education.js
@@ -1,7 +1,7 @@
 const Validator = require('validator');
 const isEmpty = require('./is-empty');
 
-module.exports = function validateExperienceInput(data) {
+module.exports = function validateEducationInput(data) {
   let errors = {};
 
   data.school = !isEmpty(data.school) ? data.school : '';


### PR DESCRIPTION
When you copied the experience validation file you forgot to change the name of the export to
education