### PR TITLE
Fix when no post is found with specified id

### DIFF
--- a/routes/api/posts.js
+++ b/routes/api/posts.js
@@ -31,7 +31,13 @@ router.get('/', (req, res) => {
 // @access  Public
 router.get('/:id', (req, res) => {
   Post.findById(req.params.id)
-    .then(post => res.json(post))
+    .then(post => {
+      if (post) {
+        res.json(post);
+      } else {
+        res.status(404).json({ nopostfound: 'No post found with that ID' })
+      }
+    })
     .catch(err =>
       res.status(404).json({ nopostfound: 'No post found with that ID' })
     );


### PR DESCRIPTION
In current logic it is not going to catch block if the post id is not found. So I added check i.e. if not post is found throw 404 error. Not sure in which scenario it is going to fall in catch block