### PR TITLE
Fix error not ever showing

### DIFF
--- a/validation/register.js
+++ b/validation/register.js
@@ -35,10 +35,10 @@ module.exports = function validateRegisterInput(data) {
 
   if (Validator.isEmpty(data.password2)) {
     errors.password2 = 'Confirm Password field is required';
-  }
-
-  if (!Validator.equals(data.password, data.password2)) {
-    errors.password2 = 'Passwords must match';
+  } else {
+    if (!Validator.equals(data.password, data.password2)) {
+      errors.password2 = 'Passwords must match';
+    }
   }
 
   return {


### PR DESCRIPTION
Wrap passwords must match in an else statment to solve error where 'Passwords must match' would always show over 'password field is required'