### PR TITLE
Replace 'logOnly' with 'logOnlyInProduction' on Redux store creation …

### DIFF
--- a/client/src/store.js
+++ b/client/src/store.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
-import { composeWithDevTools } from 'redux-devtools-extension/logOnly';
+import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 import thunk from 'redux-thunk';
 import rootReducer from './reducers';
 


### PR DESCRIPTION
…to disable extension features only in production.

More details:
[https://medium.com/@zalmoxis/using-redux-devtools-in-production-4c5b56c5600f](https://medium.com/@zalmoxis/using-redux-devtools-in-production-4c5b56c5600f)